### PR TITLE
Fix a catching polymorphic type ‘class std::exception’ by value

### DIFF
--- a/Jit/pyjit.cpp
+++ b/Jit/pyjit.cpp
@@ -532,7 +532,7 @@ long flag_long(const char* xoption, const char* envname, long _default) {
   if (envval != nullptr && envval[0] != '\0') {
     try {
       return std::stol(envval);
-    } catch (std::exception) {
+    } catch (std::exception const&) {
       JIT_LOG("Invalid value for %s: %s", envname, envval);
     }
   }


### PR DESCRIPTION
Fixes https://github.com/facebookincubator/cinder/issues/5

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
