### PR TITLE
add necessary dependencies in build env dockerfiles

### DIFF
--- a/.github/workflows/python-build-env/Dockerfile
+++ b/.github/workflows/python-build-env/Dockerfile
@@ -1,3 +1,3 @@
 FROM fedora:32
 
-RUN dnf install -y g++ git zlib-devel
+RUN dnf install -y g++ git zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl-devel xz xz-devel libffi-devel


### PR DESCRIPTION
Current dockerfile missing some important dependencies, which will caused the build cinder lack of features, like ssl support, leads to you can't install pypi.io packages since it neet https support.