### PR TITLE
doc: clarify ctypes = primitives

### DIFF
--- a/CinderDoc/static_python.rst
+++ b/CinderDoc/static_python.rst
@@ -117,7 +117,7 @@ become default.
 ``from __static__ import cbool, int8, uint8, int16, uint16, int32, uint32, int64, uint64, double``
 --------------------------------------------------------------------------------------------------
 
-These are primitive or C types. They can be used as type annotations in
+These are primitive types, or C types. They can be used as type annotations in
 Static Python modules to signal to the Cinder JIT that it can use unboxed C
 types for these values. The static compiler automatically interprets literals
 appropriately if in a primitive type context; e.g. ``x: cbool = True`` will


### PR DESCRIPTION
Add a comma to show that "primitive types" and "C types" mean the same thing.

(The old wording "primitive or C types" could be mis-read as "(primitive or C) types" at first glance.)