### PR TITLE
Add `importlib.set_lazy_imports()`

### DIFF
--- a/Include/import.h
+++ b/Include/import.h
@@ -86,7 +86,7 @@ PyAPI_FUNC(int) PyImport_AppendInittab(
     PyObject* (*initfunc)(void)
     );
 
-PyAPI_FUNC(int) PyImport_EnableLazyImports(void);
+PyAPI_FUNC(void) PyImport_EnableLazyImports(void);
 
 // TODO(lazy_imports): ifdef guards?
 PyObject * PyImport_LoadLazyImport(PyObject *lazy_import);

--- a/Include/import.h
+++ b/Include/import.h
@@ -86,6 +86,8 @@ PyAPI_FUNC(int) PyImport_AppendInittab(
     PyObject* (*initfunc)(void)
     );
 
+PyAPI_FUNC(int) PyImport_EnableLazyImports(void);
+
 // TODO(lazy_imports): ifdef guards?
 PyObject * PyImport_LoadLazyImport(PyObject *lazy_import);
 PyObject * PyImport_EagerImportName(

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -191,6 +191,9 @@ struct _is {
 
     /* the initial PyInterpreterState.threads.head */
     PyThreadState _initial_thread;
+
+    // lazy imports status in runtime
+    int lazy_imports_enabled;
 };
 
 

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -192,7 +192,7 @@ struct _is {
     /* the initial PyInterpreterState.threads.head */
     PyThreadState _initial_thread;
 
-    // lazy imports status in runtime
+    /* whether lazy imports was enabled at runtime */
     int lazy_imports_enabled;
 };
 

--- a/Lib/importlib/__init__.py
+++ b/Lib/importlib/__init__.py
@@ -72,11 +72,7 @@ def set_lazy_imports():
 
     The imported modules after this point will be lazily imported.
     """
-    enabled = _imp.set_lazy_imports()
-
-    # failed in enabling lazy imports
-    if not enabled:
-        raise SystemError('Cannot use set_lazy_imports() to enable Lazy Imports.')
+    _imp.set_lazy_imports()
 
 def invalidate_caches():
     """Call the invalidate_caches() method on all meta path finders stored in

--- a/Lib/importlib/__init__.py
+++ b/Lib/importlib/__init__.py
@@ -67,6 +67,17 @@ def is_lazy_import(dictionary, key):
     """
     return _imp.is_lazy_import(dictionary, key)
 
+def set_lazy_imports():
+    """Call set_lazy_imports() to enable Lazy Imports.
+
+    The imported modules after this point will be lazily imported.
+    """
+    enabled = _imp.set_lazy_imports()
+
+    # failed in enabling lazy imports
+    if not enabled:
+        raise SystemError('Cannot use set_lazy_imports() to enable Lazy Imports.')
+
 def invalidate_caches():
     """Call the invalidate_caches() method on all meta path finders stored in
     sys.meta_path (where implemented)."""

--- a/Python/clinic/import.c.h
+++ b/Python/clinic/import.c.h
@@ -599,7 +599,7 @@ exit:
 
 PyDoc_STRVAR(_imp_set_lazy_imports__doc__,
 "set_lazy_imports(module)\n"
-"It will enable Lazy Imports.\n"
+"Enable Lazy Imports at runtime.\n"
 );
 
 #define _IMP_SET_LAZY_IMPORTS_METHODDEF    \

--- a/Python/clinic/import.c.h
+++ b/Python/clinic/import.c.h
@@ -597,6 +597,32 @@ exit:
     return return_value;
 }
 
+PyDoc_STRVAR(_imp_set_lazy_imports__doc__,
+"set_lazy_imports(module)\n"
+"It will enable Lazy Imports.\n"
+);
+
+#define _IMP_SET_LAZY_IMPORTS_METHODDEF    \
+    {"set_lazy_imports", _PyCFunction_CAST(_imp_set_lazy_imports), METH_FASTCALL, _imp_set_lazy_imports__doc__},
+
+static PyObject *
+_imp_set_lazy_imports_impl(PyObject *module);
+
+static PyObject *
+_imp_set_lazy_imports(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
+{
+    PyObject *return_value = NULL;
+
+    if (!_PyArg_CheckPositional("set_lazy_imports", nargs, 0, 0)) {
+        goto exit;
+    }
+
+    return_value = _imp_set_lazy_imports_impl(module);
+
+exit:
+    return return_value;
+}
+
 #ifndef _IMP_CREATE_DYNAMIC_METHODDEF
     #define _IMP_CREATE_DYNAMIC_METHODDEF
 #endif /* !defined(_IMP_CREATE_DYNAMIC_METHODDEF) */

--- a/Python/import.c
+++ b/Python/import.c
@@ -26,6 +26,7 @@ extern "C" {
 
 /* Forward references */
 static PyObject *import_add_module(PyThreadState *tstate, PyObject *name);
+static bool _PyImport_LazyImportsIsEnabled(void);
 
 /* See _PyImport_FixupExtensionObject() below */
 static PyObject *extensions = NULL;
@@ -2078,7 +2079,7 @@ PyImport_ImportName(PyObject *builtins, PyObject *globals, PyObject *locals,
 {
     PyThreadState *tstate = _PyThreadState_GET();
     int verbose = _PyInterpreterState_GetConfig(tstate->interp)->verbose;
-    int lazy_imports_enabled = _PyInterpreterState_GetConfig(tstate->interp)->lazy_imports;
+    bool lazy_imports_enabled = _PyImport_LazyImportsIsEnabled();
 
     if (!lazy_imports_enabled) {
         return PyImport_EagerImportName(builtins, globals, locals, name, fromlist, level, NULL);
@@ -2784,6 +2785,18 @@ _imp_is_lazy_import_impl(PyObject *module, PyObject *dict, PyObject *key)
     Py_RETURN_FALSE;
 }
 
+static PyObject *
+_imp_set_lazy_imports_impl(PyObject *module)
+{
+    // enable lazy imports
+    int lazy_imports_status = PyImport_EnableLazyImports();
+
+    if (lazy_imports_status == 1) {
+        Py_RETURN_TRUE;
+    }
+    Py_RETURN_FALSE;
+}
+
 
 PyDoc_STRVAR(doc_imp,
 "(Extremely) low-level import machinery bits as used by importlib and imp.");
@@ -2808,6 +2821,7 @@ static PyMethodDef imp_methods[] = {
     _IMP__FIX_CO_FILENAME_METHODDEF
     _IMP_SOURCE_HASH_METHODDEF
     _IMP_IS_LAZY_IMPORT_METHODDEF
+    _IMP_SET_LAZY_IMPORTS_METHODDEF
     {NULL, NULL}  /* sentinel */
 };
 
@@ -2963,6 +2977,32 @@ PyImport_AppendInittab(const char *name, PyObject* (*initfunc)(void))
 
     return PyImport_ExtendInittab(newtab);
 }
+
+
+static bool
+_PyImport_LazyImportsIsEnabled()
+{
+    PyInterpreterState *interp = _PyInterpreterState_GET();
+    if (_PyInterpreterState_GetConfig(interp)->lazy_imports |
+        interp->lazy_imports_enabled)
+    {
+        return true;
+    }
+    return false;
+}
+
+int
+PyImport_EnableLazyImports()
+{
+    PyInterpreterState *interp = _PyInterpreterState_GET();
+    interp->lazy_imports_enabled = 1;
+
+    if (_PyImport_LazyImportsIsEnabled()) {
+        return 1;
+    }
+    return 0;
+}
+
 
 #ifdef __cplusplus
 }

--- a/Python/import.c
+++ b/Python/import.c
@@ -2984,7 +2984,7 @@ _PyImport_LazyImportsIsEnabled()
 {
     PyInterpreterState *interp = _PyInterpreterState_GET();
     if (interp->lazy_imports_enabled ||
-        _PyInterpreterState_GetConfig(interp)->lazy_imports )
+        _PyInterpreterState_GetConfig(interp)->lazy_imports)
     {
         return true;
     }

--- a/Python/import.c
+++ b/Python/import.c
@@ -2788,7 +2788,6 @@ _imp_is_lazy_import_impl(PyObject *module, PyObject *dict, PyObject *key)
 static PyObject *
 _imp_set_lazy_imports_impl(PyObject *module)
 {
-    // enable lazy imports
     PyImport_EnableLazyImports();
     Py_RETURN_NONE;
 }

--- a/Python/import.c
+++ b/Python/import.c
@@ -2983,8 +2983,8 @@ static bool
 _PyImport_LazyImportsIsEnabled()
 {
     PyInterpreterState *interp = _PyInterpreterState_GET();
-    if (_PyInterpreterState_GetConfig(interp)->lazy_imports |
-        interp->lazy_imports_enabled)
+    if (interp->lazy_imports_enabled ||
+        _PyInterpreterState_GetConfig(interp)->lazy_imports )
     {
         return true;
     }

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -651,6 +651,8 @@ pycore_create_interpreter(_PyRuntimeState *runtime,
     }
     assert(_Py_IsMainInterpreter(interp));
 
+    interp->lazy_imports_enabled = 0;
+
     status = _PyConfig_Copy(&interp->config, config);
     if (_PyStatus_EXCEPTION(status)) {
         return status;

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -651,8 +651,6 @@ pycore_create_interpreter(_PyRuntimeState *runtime,
     }
     assert(_Py_IsMainInterpreter(interp));
 
-    interp->lazy_imports_enabled = 0;
-
     status = _PyConfig_Copy(&interp->config, config);
     if (_PyStatus_EXCEPTION(status)) {
         return status;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -295,6 +295,7 @@ init_interpreter(PyInterpreterState *interp,
     PyConfig_InitPythonConfig(&interp->config);
     _PyType_InitCache(interp);
 
+    interp->lazy_imports_enabled = 0;
     interp->_initialized = 1;
 }
 


### PR DESCRIPTION
# Summary
Add `importlib.set_lazy_imports()` to  enable Lazy Imports in runtime.

# Test Plan
- If we start Python without Lazy Imports, we can use `importlib.set_lazy_imports()` to enable Lazy Imports in runtime. That is to say, after running `importlib.set_lazy_imports()`, every import should be lazy.
- If Lazy Imports is enabled at the beginning, the behavior should not change. 


## Start without Lazy Imports
Run
```
$ ./python.exe
>>> import importlib
```
If we import `json`, it should *not* be lazy.
```
>>> import json
>>> importlib.is_lazy_import(globals(), "json")
False
```

Then, we use `importlib.set_lazy_imports()` to enable Lazy Imports.
If we import `math` now, it should be lazy.
```
>>> importlib.set_lazy_imports()
>>> import math
>>> importlib.is_lazy_import(globals(), "math")
True
```
If we use `math.pi`, it would be loaded.
```
>>> math.pi
3.141592653589793
>>> importlib.is_lazy_import(globals(), "math")
False
```


## Start with Lazy Imports
Run
```
$ ./python.exe -L
>>> import importlib
```

If we import `math`, it should be lazy because we starts with `-L`.
```
>>> import math
>>> importlib.is_lazy_import(globals(), "math")
True
```

If we use `math.pi`, it would be loaded.
```
>>> math.pi
3.141592653589793
>>> importlib.is_lazy_import(globals(), "math")
False
```

If we use `importlib.set_lazy_imports()`, the behavior will not change.
If we import `json` immediately, `json` is still lazy.
```
>>> importlib.set_lazy_imports()
>>> import json
>>> importlib.is_lazy_import(globals(), "json")
True
```

## Wrong numbers of arguments
`importlib.set_lazy_import()` should not have any argument.
No matter with or without `-L`, if we give it any argument, it will return the error message.
```
>>> importlib.set_lazy_imports(123)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: set_lazy_imports() takes 0 positional arguments but 1 was given
```