### PR TITLE
Add `excluding` argument for `importlib.set_lazy_imports`

### DIFF
--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -125,6 +125,9 @@ struct _is {
     // importlib module
     PyObject *importlib;
     PyObject *lazy_loaded;
+    // modules pass this filter need to be eager when enabling lazy imports
+    PyObject *eager_filter;
+
     // override for config->use_frozen_modules (for tests)
     // (-1: "off", 1: "on", 0: no override)
     int override_frozen_modules;
@@ -194,6 +197,7 @@ struct _is {
 
     /* whether lazy imports was enabled at runtime */
     int lazy_imports_enabled;
+    int outermost_is_eager_loaded;
 };
 
 

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -125,8 +125,8 @@ struct _is {
     // importlib module
     PyObject *importlib;
     PyObject *lazy_loaded;
-    // modules pass this filter need to be eager when enabling lazy imports
-    PyObject *eager_filter;
+    // modules pass this filter need to be eager loaded when enabling lazy imports
+    PyObject *eager_loaded_filter;
 
     // override for config->use_frozen_modules (for tests)
     // (-1: "off", 1: "on", 0: no override)

--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -100,6 +100,7 @@ typedef struct {
     PyObject *lz_obj;
     PyObject *lz_next;
     int lz_resolving;
+    int lz_eager_loaded;
 } PyLazyImport;
 
 int PyLazyImport_Match(PyLazyImport *lazy_import, PyObject *mod_dict, PyObject *name);

--- a/Lib/importlib/__init__.py
+++ b/Lib/importlib/__init__.py
@@ -67,12 +67,19 @@ def is_lazy_import(dictionary, key):
     """
     return _imp.is_lazy_import(dictionary, key)
 
-def set_lazy_imports():
+def set_lazy_imports(excluding=None):
     """Call set_lazy_imports() to enable Lazy Imports.
 
     The imported modules after this point will be lazily imported.
+
+    It has an optional argument `excluding` which can set conditions for
+    specifying some modules are eagerly loaded when they are loading.
+
+    `excluding` can accept a list of module names or a callback function.
+    If a imported module matches the list or the callback function, it will
+    load all sub-modules when it is loaded.
     """
-    _imp.set_lazy_imports()
+    _imp.set_lazy_imports(excluding)
 
 def invalidate_caches():
     """Call the invalidate_caches() method on all meta path finders stored in

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -1023,6 +1023,7 @@ PyLazyImportModule_NewObject(PyObject *name, PyObject *globals, PyObject *locals
     m->lz_obj = NULL;
     m->lz_next = NULL;
     m->lz_resolving = 0;
+    m->lz_eager_loaded = -1;
     PyObject_GC_Track(m);
     return (PyObject *)m;
 }
@@ -1066,6 +1067,7 @@ PyLazyImportObject_NewObject(PyObject *from, PyObject *name)
     m->lz_obj = NULL;
     m->lz_next = NULL;
     m->lz_resolving = 0;
+    m->lz_eager_loaded = -1;
     PyObject_GC_Track(m);
     return (PyObject *)m;
 }

--- a/Python/clinic/import.c.h
+++ b/Python/clinic/import.c.h
@@ -598,26 +598,36 @@ exit:
 }
 
 PyDoc_STRVAR(_imp_set_lazy_imports__doc__,
-"set_lazy_imports(module)\n"
+"set_lazy_imports(module, eager_imports_filter)\n"
 "Enable Lazy Imports at runtime.\n"
+"`eager_imports_filter` is an optional argument.\n"
+"This filter can be a list or a callback function.\n"
 );
 
 #define _IMP_SET_LAZY_IMPORTS_METHODDEF    \
     {"set_lazy_imports", _PyCFunction_CAST(_imp_set_lazy_imports), METH_FASTCALL, _imp_set_lazy_imports__doc__},
 
 static PyObject *
-_imp_set_lazy_imports_impl(PyObject *module);
+_imp_set_lazy_imports_impl(PyObject *module, PyObject *eager_imports_filter);
 
 static PyObject *
 _imp_set_lazy_imports(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
 
-    if (!_PyArg_CheckPositional("set_lazy_imports", nargs, 0, 0)) {
+    if (!_PyArg_CheckPositional("set_lazy_imports", nargs, 1, 1)) {
         goto exit;
     }
 
-    return_value = _imp_set_lazy_imports_impl(module);
+    if ((args[0] != Py_None) &&
+        (!PyList_Check(args[0]) && !PyFunction_Check(args[0])))
+    {
+        _PyArg_BadArgument("set_lazy_imports", "argument 1", "list or callback function", args[0]);
+        goto exit;
+    }
+
+    // enable lazy imports and marked modules in `args[0]` as eager loaded
+    return_value = _imp_set_lazy_imports_impl(module, args[0]);
 
 exit:
     return return_value;

--- a/Python/clinic/import.c.h
+++ b/Python/clinic/import.c.h
@@ -598,9 +598,9 @@ exit:
 }
 
 PyDoc_STRVAR(_imp_set_lazy_imports__doc__,
-"set_lazy_imports(module, eager_imports_filter)\n"
+"set_lazy_imports(module, eager_filter)\n"
 "Enable Lazy Imports at runtime.\n"
-"`eager_imports_filter` is an optional argument.\n"
+"`eager_filter` is an optional argument.\n"
 "This filter can be a list or a callback function.\n"
 );
 
@@ -608,7 +608,7 @@ PyDoc_STRVAR(_imp_set_lazy_imports__doc__,
     {"set_lazy_imports", _PyCFunction_CAST(_imp_set_lazy_imports), METH_FASTCALL, _imp_set_lazy_imports__doc__},
 
 static PyObject *
-_imp_set_lazy_imports_impl(PyObject *module, PyObject *eager_imports_filter);
+_imp_set_lazy_imports_impl(PyObject *module, PyObject *eager_filter);
 
 static PyObject *
 _imp_set_lazy_imports(PyObject *module, PyObject *const *args, Py_ssize_t nargs)

--- a/Python/import.c
+++ b/Python/import.c
@@ -2272,12 +2272,12 @@ PyImport_LoadLazyImport(PyObject *lazy_import)  // was PyImport_ImportDeferred(P
 
         if (lz->lz_eager_loaded == 1) {
             obj = PyImport_EagerImportName(PyEval_GetBuiltins(),
-                                       lz->lz_globals,
-                                       lz->lz_locals,
-                                       lz->lz_name,
-                                       lz->lz_fromlist,
-                                       lz->lz_level,
-                                       NULL);
+                                           lz->lz_globals,
+                                           lz->lz_locals,
+                                           lz->lz_name,
+                                           lz->lz_fromlist,
+                                           lz->lz_level,
+                                           NULL);
         }
         else {
             obj = _imp_load_lazy_import_impl(lz);

--- a/Python/import.c
+++ b/Python/import.c
@@ -2846,13 +2846,14 @@ static PyObject *
 _imp_set_lazy_imports_impl(PyObject *module, PyObject *eager_filter)
 {
     PyInterpreterState *interp = _PyInterpreterState_GET();
+    if (interp->eager_loaded_filter != NULL &&
+        PySet_Check(interp->eager_loaded_filter))
+    {
+        Py_CLEAR(interp->eager_loaded_filter);
+    }
 
     // eager_filter is a list
     if (PyList_Check(eager_filter)) {
-        if (interp->eager_loaded_filter != NULL) {
-            Py_CLEAR(interp->eager_loaded_filter);
-        }
-
         interp->eager_loaded_filter = PySet_New(NULL);
         assert(interp->eager_loaded_filter != NULL);
 
@@ -2866,10 +2867,6 @@ _imp_set_lazy_imports_impl(PyObject *module, PyObject *eager_filter)
     }
     // eager_filter is a callback function
     else if (PyFunction_Check(eager_filter)) {
-        if (interp->eager_loaded_filter != NULL) {
-            Py_CLEAR(interp->eager_loaded_filter);
-        }
-
         // set the callback function
         interp->eager_loaded_filter = eager_filter;
         assert(interp->eager_loaded_filter != NULL);

--- a/Python/import.c
+++ b/Python/import.c
@@ -2230,7 +2230,7 @@ _PyImport_LazyImportMatchEagerLoadedFilter(PyObject *name)
 
     // check if this module satisfied with `excluding` condition
     // i.e. module name is in the excluded list or matches callback function
-    PyObject *filter = interp->eager_filter;
+    PyObject *filter = interp->eager_loaded_filter;
 
     if (filter == NULL) {
         return 0;
@@ -2843,40 +2843,40 @@ _imp_is_lazy_import_impl(PyObject *module, PyObject *dict, PyObject *key)
 }
 
 static PyObject *
-_imp_set_lazy_imports_impl(PyObject *module, PyObject *eager_imports_filter)
+_imp_set_lazy_imports_impl(PyObject *module, PyObject *eager_filter)
 {
     PyInterpreterState *interp = _PyInterpreterState_GET();
 
-    // eager_imports_filter is a list
-    if (PyList_Check(eager_imports_filter)) {
-        if (interp->eager_filter != NULL) {
-            Py_CLEAR(interp->eager_filter);
+    // eager_filter is a list
+    if (PyList_Check(eager_filter)) {
+        if (interp->eager_loaded_filter != NULL) {
+            Py_CLEAR(interp->eager_loaded_filter);
         }
 
-        interp->eager_filter = PySet_New(NULL);
-        assert(interp->eager_filter != NULL);
+        interp->eager_loaded_filter = PySet_New(NULL);
+        assert(interp->eager_loaded_filter != NULL);
 
-        // record modules which will need to be eager
+        // record modules which will need to be eager loaded
         Py_ssize_t i, n_imports;
-        n_imports = PyList_Size(eager_imports_filter);
+        n_imports = PyList_Size(eager_filter);
         for (i = 0; i < n_imports; i++) {
-            PyObject *eager_import = PyList_GetItem(eager_imports_filter, i);
-            PySet_Add(interp->eager_filter, eager_import);
+            PyObject *eager_import = PyList_GetItem(eager_filter, i);
+            PySet_Add(interp->eager_loaded_filter, eager_import);
         }
     }
-    // eager_imports_filter is a callback function
-    else if (PyFunction_Check(eager_imports_filter)) {
-        if (interp->eager_filter != NULL) {
-            Py_CLEAR(interp->eager_filter);
+    // eager_filter is a callback function
+    else if (PyFunction_Check(eager_filter)) {
+        if (interp->eager_loaded_filter != NULL) {
+            Py_CLEAR(interp->eager_loaded_filter);
         }
 
         // set the callback function
-        interp->eager_filter = eager_imports_filter;
-        assert(interp->eager_filter != NULL);
+        interp->eager_loaded_filter = eager_filter;
+        assert(interp->eager_loaded_filter != NULL);
     }
-    // eager_imports_filter is empty
+    // eager_filter is empty
     else {
-        assert(eager_imports_filter == Py_None);
+        assert(eager_filter == Py_None);
     }
 
     PyImport_EnableLazyImports();

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -413,7 +413,7 @@ interpreter_clear(PyInterpreterState *interp, PyThreadState *tstate)
     Py_CLEAR(interp->importlib);
     Py_CLEAR(interp->import_func);
     Py_CLEAR(interp->lazy_loaded);
-    Py_CLEAR(interp->eager_filter);
+    Py_CLEAR(interp->eager_loaded_filter);
     Py_CLEAR(interp->dict);
 #ifdef HAVE_FORK
     Py_CLEAR(interp->before_forkers);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -296,6 +296,8 @@ init_interpreter(PyInterpreterState *interp,
     _PyType_InitCache(interp);
 
     interp->lazy_imports_enabled = 0;
+    interp->outermost_is_eager_loaded = -1;
+
     interp->_initialized = 1;
 }
 
@@ -411,6 +413,7 @@ interpreter_clear(PyInterpreterState *interp, PyThreadState *tstate)
     Py_CLEAR(interp->importlib);
     Py_CLEAR(interp->import_func);
     Py_CLEAR(interp->lazy_loaded);
+    Py_CLEAR(interp->eager_filter);
     Py_CLEAR(interp->dict);
 #ifdef HAVE_FORK
     Py_CLEAR(interp->before_forkers);


### PR DESCRIPTION
# Summary
Add an optional argument `excluding` for `importlib.set_lazy_imports`.

# Test Plan

`excluding` is an optional argument for importlib.set_lazy_imports(). It should be a list or a callback function, containing all the modules would like to be eagerly loaded.

For example, let us have a module called `foo.py`.
```
# foo.py
import importlib
import bar
```

If we call  `importlib.set_lazy_imports(excluding=["foo"])`, two actions will be executed at this moment.
1. Enable Lazy Imports from now
2. `foo` is marked as eagerly loaded in the future

That is, if we `import foo` and run `foo`, <ins>it will load `importlib` and `bar` at the same time</ins>.

## Pre-req
Create `foo.py` and `bar.py` under the same path of `python.exe`.
```
# foo.py
print("I'm foooooo.")
import importlib
import bar
assert(not importlib.is_lazy_import(globals(), "bar"))
```
```
# bar.py
print("I'm bar!")
```

## Start with/without Lazy Imports
No matter with or without `-L`, the expected results are the same in the following tests. The only difference is we need to use `./python.exe -L` rather than `./python.exe` if we would like to start with Lazy Imports at the beginning.

### Use a list as a filter
Run
```
$ ./python.exe
>>> import importlib
>>> importlib.set_lazy_imports(excluding=["foo"])
>>> import foo
>>> assert(importlib.is_lazy_import(globals(), "foo"))
>>> foo
```
Expected result:
```
I'm foooooo.
I'm bar!
```

### Use a callback function as a filter
Run
```
$ ./python.exe
>>> import importlib
>>> def eager_imports(name):
...    return name == "foo"
>>> importlib.set_lazy_imports(excluding=eager_imports)
>>> import foo
>>> assert(importlib.is_lazy_import(globals(), "foo"))
>>> foo  # Force loading `foo`
```
Expected result:
```
I'm foooooo.
I'm bar!
```

### Correct the excluding argument by running again
If we would like to change our `excluding` setting, we can run the command `set_lazy_imports` with the new `excluding` argument again.

For example, run
```
$ ./python.exe
>>> import importlib
```

Set the first `excluding` argument as the `Hello` callback function.
```
>>> def Hello(name):
...     return "Hello" == name
...
>>>
>>> importlib.set_lazy_imports(excluding=Hello)
>>> import math
>>> importlib.is_lazy_import(globals(), "math")
True
>>> math.pi
3.141592653589793
>>> importlib.is_lazy_import(globals(), "math")
False
```

Correct the `excluding` argument by setting nothing.
```
importlib.set_lazy_imports()
```

Correct the `excluding` argument by using the `eager_foo` callback function.

```
>>> def eager_foo(name):
...     return name == "foo"
...
>>> importlib.set_lazy_imports(excluding=eager_foo)
>>> import foo
>>> foo
I'm foooooo.
I'm bar!
```

## Wrong type of the argument
No matter with or without `-L`, if a parameter use in `excluding` is not a `list` or a `callback`, it will return the TypeError message. 
```
>>> import importlib
>>> importlib.set_lazy_imports(excluding=123)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/harperlin/Documents/GitHub/crahsy_0619/Lib/importlib/__init__.py", line 82, in set_lazy_imports
    _imp.set_lazy_imports(excluding)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: set_lazy_imports() argument 1 must be list or callback function, not int
```