### PR TITLE
Add eager_imports context manager

### DIFF
--- a/Lib/importlib/__init__.py
+++ b/Lib/importlib/__init__.py
@@ -67,12 +67,21 @@ def is_lazy_import(dictionary, key):
     """
     return _imp.is_lazy_import(dictionary, key)
 
+
 def set_lazy_imports():
     """Call set_lazy_imports() to enable Lazy Imports.
 
     The imported modules after this point will be lazily imported.
     """
     _imp.set_lazy_imports()
+
+
+class eager_imports:
+    def __enter__(self):
+        pass
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        pass
+
 
 def invalidate_caches():
     """Call the invalidate_caches() method on all meta path finders stored in


### PR DESCRIPTION
# Summary
Add a context manager `importlib.eager_imports()` to make imports in it **shallow** eager.

# Test Plan
I followed the functional spec of `importlib.eager_imports()` in [PEP690](https://peps.python.org/pep-0690/) to implement this. Imports within context managers are always eager no matter with or without `-L`, so I built a **null** context manger for `mportlib.eager_imports()`. 

However, the context manager does not force all imports to be recursively eager. The (sub) imports in the imported module in context manager's scope will still be lazy if Lazy Imports is enabled.

## Pre-req
Create `test.py`, `foo.py` and `bar.py` under the same path of `python.exe`.

### test.py
```
import importlib

with importlib.eager_imports():
    import math
    import foo

import sys

print("Is `math` lazy?", importlib.is_lazy_import(globals(), "math"))
print("Is `foo` lazy?", importlib.is_lazy_import(globals(), "foo"))
print("Is `sys` lazy?", importlib.is_lazy_import(globals(), "sys"))
```
### foo.py
```
print("foooooo.")
import os
import bar
```
### bar.py
```
print("I'm bar!")
```

## Test with Lazy Imports

Run
```
./python.exe -L test.py
```

Expected results:
`bar` wasn't eagerly imported because the context manager `eager_imports()` only made `import foo` **shallow** eager.
```
foooooo.
Is `math` lazy? False
Is `foo` lazy? False
Is `sys` lazy? True
```

## Test without Lazy Imports
Run
```
./python.exe test.py
```

Expected results:
`bar` was also eagerly imported because we did not use Lazy Imports.
```
foooooo.
I'm bar!
Is `math` lazy? False
Is `foo` lazy? False
Is `sys` lazy? False
```
