### PR TITLE
Add LazyImportError

### DIFF
--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -100,6 +100,8 @@ typedef struct {
     PyObject *lz_obj;
     PyObject *lz_next;
     int lz_resolving;
+    PyObject *lz_filename;
+    int lz_lineno;
 } PyLazyImport;
 
 int PyLazyImport_Match(PyLazyImport *lazy_import, PyObject *mod_dict, PyObject *name);

--- a/Include/pyerrors.h
+++ b/Include/pyerrors.h
@@ -90,6 +90,7 @@ PyAPI_DATA(PyObject *) PyExc_ImportError;
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03060000
 PyAPI_DATA(PyObject *) PyExc_ModuleNotFoundError;
 #endif
+PyAPI_DATA(PyObject *) PyExc_LazyImportError;
 PyAPI_DATA(PyObject *) PyExc_IndexError;
 PyAPI_DATA(PyObject *) PyExc_KeyError;
 PyAPI_DATA(PyObject *) PyExc_KeyboardInterrupt;

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -1612,6 +1612,13 @@ MiddlingExtendsException(PyExc_ImportError, ModuleNotFoundError, ImportError,
                          "Module not found.");
 
 /*
+ *    LazyImportError extends ImportError
+ */
+
+MiddlingExtendsException(PyExc_ImportError, LazyImportError, ImportError,
+                         "Module import errors when enabling Lazy Imports.");
+
+/*
  *    OSError extends Exception
  */
 
@@ -3533,6 +3540,7 @@ static struct static_exception static_exceptions[] = {
     ITEM(IndexError),  // base: LookupError(Exception)
     ITEM(KeyError),  // base: LookupError(Exception)
     ITEM(ModuleNotFoundError), // base: ImportError(Exception)
+    ITEM(LazyImportError), // base: ImportError(Exception)
     ITEM(NotImplementedError),  // base: RuntimeError(Exception)
     ITEM(RecursionError),  // base: RuntimeError(Exception)
     ITEM(UnboundLocalError), // base: NameError(Exception)

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -1616,7 +1616,7 @@ MiddlingExtendsException(PyExc_ImportError, ModuleNotFoundError, ImportError,
  */
 
 MiddlingExtendsException(PyExc_ImportError, LazyImportError, ImportError,
-                         "Module import errors when enabling Lazy Imports.");
+                         "Errors raised when loading a lazy import.");
 
 /*
  *    OSError extends Exception

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -1085,6 +1085,7 @@ lazy_import_dealloc(PyLazyImport *m)
     Py_XDECREF(m->lz_level);
     Py_XDECREF(m->lz_obj);
     Py_XDECREF(m->lz_next);
+    Py_XDECREF(m->lz_filename);
     Py_TYPE(m)->tp_free((PyObject *)m);
 }
 
@@ -1129,6 +1130,7 @@ lazy_import_traverse(PyLazyImport *m, visitproc visit, void *arg)
     Py_VISIT(m->lz_level);
     Py_VISIT(m->lz_obj);
     Py_VISIT(m->lz_next);
+    Py_VISIT(m->lz_filename);
     return 0;
 }
 
@@ -1143,6 +1145,7 @@ lazy_import_clear(PyLazyImport *m)
     Py_CLEAR(m->lz_level);
     Py_CLEAR(m->lz_obj);
     Py_CLEAR(m->lz_next);
+    Py_CLEAR(m->lz_filename);
     return 0;
 }
 

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -1023,6 +1023,8 @@ PyLazyImportModule_NewObject(PyObject *name, PyObject *globals, PyObject *locals
     m->lz_obj = NULL;
     m->lz_next = NULL;
     m->lz_resolving = 0;
+    m->lz_filename = NULL;
+    m->lz_lineno = 0;
     PyObject_GC_Track(m);
     return (PyObject *)m;
 }
@@ -1066,6 +1068,8 @@ PyLazyImportObject_NewObject(PyObject *from, PyObject *name)
     m->lz_obj = NULL;
     m->lz_next = NULL;
     m->lz_resolving = 0;
+    m->lz_filename = NULL;
+    m->lz_lineno = 0;
     PyObject_GC_Track(m);
     return (PyObject *)m;
 }

--- a/Python/import.c
+++ b/Python/import.c
@@ -1972,7 +1972,9 @@ _PyImport_LazyImportModuleLevelObject(
         // store the original import filename and line for LazyImportError
         PyFrameObject *frame = PyThreadState_GetFrame(tstate);
         PyCodeObject *code = PyFrame_GetCode(frame);
-        ((PyLazyImport *)lazy_module)->lz_filename = code->co_filename;
+        PyObject *filename = code->co_filename;
+        Py_INCREF(filename);
+        ((PyLazyImport *)lazy_module)->lz_filename = filename;
         ((PyLazyImport *)lazy_module)->lz_lineno = PyFrame_GetLineNumber(frame);
 
         /* Crazy side-effects! */

--- a/Python/import.c
+++ b/Python/import.c
@@ -2234,12 +2234,9 @@ PyImport_LoadLazyImport(PyObject *lazy_import)  // was PyImport_ImportDeferred(P
             lz->lz_obj = obj;
         }
         else {
-            PyObject *exc, *val, *tb;
-            PyErr_Fetch(&exc, &val, &tb);
-            PyErr_Format(PyExc_LazyImportError,
-                         "Improper Module import causes this error "
-                         "when enabling Lazy Imports.");
-            _PyErr_ChainExceptions(exc, val, tb);
+            _PyErr_FormatFromCause(PyExc_LazyImportError,
+                                   "Improper Module import causes this error "
+                                   "when enabling Lazy Imports.");
         }
     }
     return obj;

--- a/Python/import.c
+++ b/Python/import.c
@@ -2244,10 +2244,10 @@ PyImport_LoadLazyImport(PyObject *lazy_import)  // was PyImport_ImportDeferred(P
             // only preserve the most recent (innermost) occured LazyImportError
             if (tstate->curexc_type != PyExc_LazyImportError) {
                 _PyErr_FormatFromCause(PyExc_LazyImportError,
-                                    "Error occurred when loading a lazy import. "
-                                    "Original import was at file %s, line %d",
-                                    filename,
-                                    line);
+                                       "Error occurred when loading a lazy import. "
+                                       "Original import was at file %s, line %d",
+                                       filename,
+                                       line);
             }
         }
     }

--- a/Python/import.c
+++ b/Python/import.c
@@ -2230,8 +2230,17 @@ PyImport_LoadLazyImport(PyObject *lazy_import)  // was PyImport_ImportDeferred(P
     PyObject *obj = lz->lz_obj;
     if (obj == NULL) {
         obj = _imp_load_lazy_import_impl(lz);
-        if (obj != NULL)
+        if (obj != NULL) {
             lz->lz_obj = obj;
+        }
+        else {
+            PyObject *exc, *val, *tb;
+            PyErr_Fetch(&exc, &val, &tb);
+            PyErr_Format(PyExc_LazyImportError,
+                         "Improper Module import causes this error "
+                         "when enabling Lazy Imports.");
+            _PyErr_ChainExceptions(exc, val, tb);
+        }
     }
     return obj;
 }

--- a/Python/import.c
+++ b/Python/import.c
@@ -2238,7 +2238,7 @@ PyImport_LoadLazyImport(PyObject *lazy_import)  // was PyImport_ImportDeferred(P
         else {
             PyFrameObject* frame = PyThreadState_GetFrame(tstate);
             PyCodeObject *code = PyFrame_GetCode(frame);
-            PyObject *filename = PyUnicode_AsUTF8(code->co_filename);
+            const char *filename = PyUnicode_AsUTF8(code->co_filename);
             int line = PyFrame_GetLineNumber(frame);
 
             // only preserve the most recent (innermost) occured LazyImportError

--- a/Python/import.c
+++ b/Python/import.c
@@ -1972,9 +1972,8 @@ _PyImport_LazyImportModuleLevelObject(
         // store the original import filename and line for LazyImportError
         PyFrameObject *frame = PyThreadState_GetFrame(tstate);
         PyCodeObject *code = PyFrame_GetCode(frame);
-        PyObject *filename = code->co_filename;
-        Py_INCREF(filename);
-        ((PyLazyImport *)lazy_module)->lz_filename = filename;
+        Py_INCREF(code->co_filename);
+        ((PyLazyImport *)lazy_module)->lz_filename = code->co_filename;
         ((PyLazyImport *)lazy_module)->lz_lineno = PyFrame_GetLineNumber(frame);
 
         /* Crazy side-effects! */


### PR DESCRIPTION
# Summary
Wrap every deferred import exception in a new exception type `LazyImportError`, chained to the original exception.

# Test Plan
- When Lazy Imports is not enabled, every error will change nothing.
- When Lazy Imports is enabled, every error cause by a (lazy) import action will wrap into `LazyImportError`. Thus, the error will show `LazyImportError` and link back to the original exception with tracebacks.

## Pre-req
Create `foo.py`, `value_error.py`, `run_foo.py`, and `run_value_error.py` under the same path of `python.exe`.

### foo.py
```
import applepie
applepie
```
### value_error.py
```
raise ValueError("")
```
### run_foo.py
```
import foo
foo
```
### run_value_error.py
```
import value_error
value_error
```

## Test without Lazy Imports
### Test ModuleNotFoundError
Run
```
./python.exe run_foo.py
```
Expected results:
```
Traceback (most recent call last):
  File "/Users/harperlin/Documents/GitHub/crashy_0623/run_foo.py", line 1, in <module>
    import foo
    ^^^^^^^^^^
  File "/Users/harperlin/Documents/GitHub/crashy_0623/foo.py", line 1, in <module>
    import applepie
    ^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'applepie'
```

### Test ValueError
Run
```
./python.exe run_value_error.py
```
Expected results:
```
Traceback (most recent call last):
  File "/Users/harperlin/Documents/GitHub/crashy_0623/run_value_error.py", line 1, in <module>
    import value_error
    ^^^^^^^^^^^^^^^^^^
  File "/Users/harperlin/Documents/GitHub/crashy_0623/value_error.py", line 1, in <module>
    raise ValueError("")
    ^^^^^^^^^^^^^^^^^^^^
ValueError
```


## Test with Lazy Imports
### Test ModuleNotFoundError
Run
```
./python.exe -L run_foo.py
```
Expected results:
```
Traceback (most recent call last):
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1142, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'applepie'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/harperlin/Documents/GitHub/crashy_0623/run_foo.py", line 2, in <module>
    foo
    ^^^
  File "/Users/harperlin/Documents/GitHub/crashy_0623/foo.py", line 2, in <module>
    applepie
    ^^^^^^^^
LazyImportError: Error occurred when loading a lazy import. Original import was at file /Users/harperlin/Documents/GitHub/crashy_0623/foo.py, line 1
```

### Test ValueError
Run
```
./python.exe -L run_value_error.py
```
Expected results:
```
Traceback (most recent call last):
  File "/Users/harperlin/Documents/GitHub/crashy_0623/value_error.py", line 1, in <module>
    raise ValueError("")
    ^^^^^^^^^^^^^^^^^^^^
ValueError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/harperlin/Documents/GitHub/crashy_0623/run_value_error.py", line 2, in <module>
    value_error
    ^^^^^^^^^^^
LazyImportError: Error occurred when loading a lazy import. Original import was at file /Users/harperlin/Documents/GitHub/crashy_0623/run_value_error.py, line 1
```
