### PR TITLE
Add lazy import error in import from

### DIFF
--- a/Lib/test/exception_hierarchy.txt
+++ b/Lib/test/exception_hierarchy.txt
@@ -14,7 +14,8 @@ BaseException
       ├── EOFError
       ├── ExceptionGroup [BaseExceptionGroup]
       ├── ImportError
-      │    └── ModuleNotFoundError
+      │    ├── ModuleNotFoundError
+      │    └── LazyImportError
       ├── LookupError
       │    ├── IndexError
       │    └── KeyError

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -995,6 +995,18 @@ PyTypeObject PyModule_Type = {
     PyObject_GC_Del,                            /* tp_free */
 };
 
+static void
+store_lazyimporterror_info(PyLazyImport *lazy_module)
+{
+    // store the original import filename and line for LazyImportError
+    PyThreadState *tstate = _PyThreadState_GET();
+    PyFrameObject *frame = PyThreadState_GetFrame(tstate);
+    PyCodeObject *code = PyFrame_GetCode(frame);
+    Py_INCREF(code->co_filename);
+    lazy_module->lz_filename = code->co_filename;
+    lazy_module->lz_lineno = PyFrame_GetLineNumber(frame);
+}
+
 PyObject *
 PyLazyImportModule_NewObject(PyObject *name, PyObject *globals, PyObject *locals, PyObject *fromlist, PyObject *level)
 {
@@ -1023,8 +1035,7 @@ PyLazyImportModule_NewObject(PyObject *name, PyObject *globals, PyObject *locals
     m->lz_obj = NULL;
     m->lz_next = NULL;
     m->lz_resolving = 0;
-    m->lz_filename = NULL;
-    m->lz_lineno = 0;
+    store_lazyimporterror_info(m);
     PyObject_GC_Track(m);
     return (PyObject *)m;
 }
@@ -1068,8 +1079,7 @@ PyLazyImportObject_NewObject(PyObject *from, PyObject *name)
     m->lz_obj = NULL;
     m->lz_next = NULL;
     m->lz_resolving = 0;
-    m->lz_filename = NULL;
-    m->lz_lineno = 0;
+    store_lazyimporterror_info(m);
     PyObject_GC_Track(m);
     return (PyObject *)m;
 }

--- a/Python/import.c
+++ b/Python/import.c
@@ -1969,13 +1969,6 @@ _PyImport_LazyImportModuleLevelObject(
                 goto error;
         }
 
-        // store the original import filename and line for LazyImportError
-        PyFrameObject *frame = PyThreadState_GetFrame(tstate);
-        PyCodeObject *code = PyFrame_GetCode(frame);
-        Py_INCREF(code->co_filename);
-        ((PyLazyImport *)lazy_module)->lz_filename = code->co_filename;
-        ((PyLazyImport *)lazy_module)->lz_lineno = PyFrame_GetLineNumber(frame);
-
         /* Crazy side-effects! */
         PyObject *type, *value, *traceback;
         PyErr_Fetch(&type, &value, &traceback);
@@ -2242,7 +2235,9 @@ PyImport_LoadLazyImport(PyObject *lazy_import)  // was PyImport_ImportDeferred(P
             lz->lz_obj = obj;
         }
         else {
+            assert(lz->lz_filename != NULL);
             PyThreadState *tstate = _PyThreadState_GET();
+
             // only preserve the most recent (innermost) occured LazyImportError
             if (tstate->curexc_type != PyExc_LazyImportError) {
                 _PyErr_FormatFromCauseTstate(tstate,

--- a/Python/import.c
+++ b/Python/import.c
@@ -2234,8 +2234,6 @@ PyImport_LoadLazyImport(PyObject *lazy_import)  // was PyImport_ImportDeferred(P
 {
     assert(lazy_import != NULL);
     assert(PyLazyImport_CheckExact(lazy_import));
-    PyThreadState *tstate = _PyThreadState_GET();
-
     PyLazyImport *lz = (PyLazyImport *)lazy_import;
     PyObject *obj = lz->lz_obj;
     if (obj == NULL) {

--- a/Python/import.c
+++ b/Python/import.c
@@ -2234,6 +2234,8 @@ PyImport_LoadLazyImport(PyObject *lazy_import)  // was PyImport_ImportDeferred(P
 {
     assert(lazy_import != NULL);
     assert(PyLazyImport_CheckExact(lazy_import));
+    PyThreadState *tstate = _PyThreadState_GET();
+
     PyLazyImport *lz = (PyLazyImport *)lazy_import;
     PyObject *obj = lz->lz_obj;
     if (obj == NULL) {


### PR DESCRIPTION
# Summary
- This PR allows Lazy Import to raise `LazyImportError` in a case like `from bakery import applepie`.
- We added `LazyImportError` into `exception_hierarchy.txt`, allowing the backporting can pass `test_baseexception`. (may need a minor format change when backporting to cinder3.10)
- We also found a way to fix the error in `test_doctest`, but `test_doctest.py` has a lot of difference between the crashy branch and cinder3.10. Thus, we noted the fix down here.

# Test Plan

## Pre-req
We has the same test plan as https://github.com/facebookincubator/cinder/pull/82, but we additionally create `foo2.py` and `run_foo2.py` under the same path of `python.exe`.
### foo2.py
```
from bakery import applepie
applepie
```
### run_foo2.py
```
import foo2
foo2
```

## Test without Lazy Import
Run
```
./python.exe run_foo2.py
```
Expected result:
```
Traceback (most recent call last):
  File "/Users/harperlin/Documents/GitHub/crashy_0623/run_foo2.py", line 1, in <module>
    import foo2
    ^^^^^^^^^^^
  File "/Users/harperlin/Documents/GitHub/crashy_0623/foo2.py", line 1, in <module>
    from bakery import applepie
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'bakery'
```

Other testing results should be the same as https://github.com/facebookincubator/cinder/pull/82.

## Test with Lazy Import
Run
```
./python.exe -L run_foo2.py
```
Expected result:
```
Traceback (most recent call last):
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1142, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'bakery'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/harperlin/Documents/GitHub/crashy_0623/run_foo2.py", line 2, in <module>
    foo2
    ^^^^
  File "/Users/harperlin/Documents/GitHub/crashy_0623/foo2.py", line 2, in <module>
    applepie
    ^^^^^^^^
LazyImportError: Error occurred when loading a lazy import. Original import was at file /Users/harperlin/Documents/GitHub/crashy_0623/foo2.py, line 1
```

Other testing results should be the same as https://github.com/facebookincubator/cinder/pull/82.

## Fix test_doctest failure in cinder3.10
We should increase one object count in `builtins` for `LazyImportError`. Therefore, if we change the upper bound value from `836` to `837`, we can fix this testing failure.
![image](https://user-images.githubusercontent.com/18440101/176288293-4552dd22-ba3e-411c-89ac-736cf285b113.png)
