### PR TITLE
Add Lazy Imports test suite framework

### DIFF
--- a/Lib/importlib/__init__.py
+++ b/Lib/importlib/__init__.py
@@ -76,6 +76,15 @@ def set_lazy_imports():
     _imp.set_lazy_imports()
 
 
+def is_lazy_imports_enabled():
+    """Check if Lazy Imports is enabled
+
+    Return true if Lazy Imports is enabled.
+    Return false if Lazy Imports is not enabled.
+    """
+    return _imp.is_lazy_imports_enabled()
+
+
 class eager_imports:
     def __enter__(self):
         pass

--- a/Lib/test/test_lazy_imports.py
+++ b/Lib/test/test_lazy_imports.py
@@ -5,11 +5,11 @@ class TestLazyImports(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(TestLazyImports, self).__init__(*args, **kwargs)
 
-    @unittest.skipIfLazyImportsIsDisabled("Skip this test when Lazy Import is disabled.")
+    @unittest.skipIfLazyImportsIsDisabled("Test relevant only when running with lazy imports enabled.")
     def test_lazy_imports_is_enabled(self):
         self.assertTrue(importlib.is_lazy_imports_enabled())
 
-    @unittest.skipIfLazyImportsIsEnabled("Skip this test when Lazy Import is enabled.")
+    @unittest.skipIfLazyImportsIsEnabled("Test relevant only when running with lazy imports disabled.")
     def test_lazy_imports_is_disabled(self):
         self.assertFalse(importlib.is_lazy_imports_enabled())
 

--- a/Lib/test/test_lazy_imports.py
+++ b/Lib/test/test_lazy_imports.py
@@ -1,0 +1,17 @@
+import importlib
+import unittest
+
+class TestLazyImports(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super(TestLazyImports, self).__init__(*args, **kwargs)
+
+    @unittest.skipIfLazyImportsIsDisabled("Skip this test when Lazy Import is disabled.")
+    def test_lazy_imports_is_enabled(self):
+        self.assertTrue(importlib.is_lazy_imports_enabled())
+
+    @unittest.skipIfLazyImportsIsEnabled("Skip this test when Lazy Import is enabled.")
+    def test_lazy_imports_is_disabled(self):
+        self.assertFalse(importlib.is_lazy_imports_enabled())
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Lib/unittest/__init__.py
+++ b/Lib/unittest/__init__.py
@@ -47,6 +47,7 @@ SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 __all__ = ['TestResult', 'TestCase', 'IsolatedAsyncioTestCase', 'TestSuite',
            'TextTestRunner', 'TestLoader', 'FunctionTestCase', 'main',
            'defaultTestLoader', 'SkipTest', 'skip', 'skipIf', 'skipUnless',
+           'skipIfLazyImportsIsEnabled', 'skipIfLazyImportsIsDisabled',
            'expectedFailure', 'TextTestResult', 'installHandler',
            'registerResult', 'removeResult', 'removeHandler',
            'addModuleCleanup', 'doModuleCleanups', 'enterModuleContext']
@@ -59,8 +60,9 @@ __unittest = True
 
 from .result import TestResult
 from .case import (addModuleCleanup, TestCase, FunctionTestCase, SkipTest, skip,
-                   skipIf, skipUnless, expectedFailure, doModuleCleanups,
-                   enterModuleContext)
+                   skipIf, skipUnless, skipIfLazyImportsIsEnabled,
+                   skipIfLazyImportsIsDisabled, expectedFailure,
+                   doModuleCleanups, enterModuleContext)
 from .suite import BaseTestSuite, TestSuite
 from .loader import TestLoader, defaultTestLoader
 from .main import TestProgram, main

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -10,6 +10,7 @@ import collections
 import contextlib
 import traceback
 import types
+import importlib
 
 from . import result
 from .util import (strclass, safe_repr, _count_diff_all_purpose,
@@ -177,6 +178,16 @@ def skipUnless(condition, reason):
     Skip a test unless the condition is true.
     """
     if not condition:
+        return skip(reason)
+    return _id
+
+def skipIfLazyImportsIsEnabled(reason):
+    if importlib.is_lazy_imports_enabled():
+        return skip(reason)
+    return _id
+
+def skipIfLazyImportsIsDisabled(reason):
+    if not importlib.is_lazy_imports_enabled():
         return skip(reason)
     return _id
 

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1666,6 +1666,12 @@ cleantest: all
 test:		@DEF_MAKE_RULE@ platform
 		$(TESTRUNNER) $(TESTOPTS)
 
+# Run the basic set of regression tests with Lazy Imports.
+# The covered tests is the same as `make test`.
+TESTRUNNERLZ= $(TESTPYTHON) -L $(srcdir)/Tools/scripts/run_tests.py
+test_with_lazy_imports: all platform
+	$(TESTRUNNERLZ) $(TESTOPTS)
+
 # Run the full test suite twice - once without .pyc files, and once with.
 # In the past, we've had problems where bugs in the marshalling or
 # elsewhere caused bytecode read from .pyc files to behave differently

--- a/Python/clinic/import.c.h
+++ b/Python/clinic/import.c.h
@@ -623,6 +623,25 @@ exit:
     return return_value;
 }
 
+PyDoc_STRVAR(_imp_is_lazy_imports_enabled__doc__,
+"is_lazy_imports_enabled($module, /)\n"
+"--\n"
+"\n"
+"Check lazy imports is enabled or not.");
+
+#define _IMP_IS_LAZY_IMPORTS_ENABLED_METHODDEF    \
+    {"is_lazy_imports_enabled", (PyCFunction)_imp_is_lazy_imports_enabled, METH_NOARGS, _imp_is_lazy_imports_enabled__doc__},
+
+static PyObject *
+_imp_is_lazy_imports_enabled_impl(PyObject *module);
+
+static PyObject *
+_imp_is_lazy_imports_enabled(PyObject *module, PyObject *Py_UNUSED(ignored))
+{
+    return _imp_is_lazy_imports_enabled_impl(module);
+}
+
+
 #ifndef _IMP_CREATE_DYNAMIC_METHODDEF
     #define _IMP_CREATE_DYNAMIC_METHODDEF
 #endif /* !defined(_IMP_CREATE_DYNAMIC_METHODDEF) */

--- a/Python/import.c
+++ b/Python/import.c
@@ -2792,6 +2792,15 @@ _imp_set_lazy_imports_impl(PyObject *module)
     Py_RETURN_NONE;
 }
 
+static PyObject *
+_imp_is_lazy_imports_enabled_impl(PyObject *module)
+{
+    if (_PyImport_IsLazyImportsEnabled()) {
+        Py_RETURN_TRUE;
+    }
+    Py_RETURN_FALSE;
+}
+
 
 PyDoc_STRVAR(doc_imp,
 "(Extremely) low-level import machinery bits as used by importlib and imp.");
@@ -2817,6 +2826,7 @@ static PyMethodDef imp_methods[] = {
     _IMP_SOURCE_HASH_METHODDEF
     _IMP_IS_LAZY_IMPORT_METHODDEF
     _IMP_SET_LAZY_IMPORTS_METHODDEF
+    _IMP_IS_LAZY_IMPORTS_ENABLED_METHODDEF
     {NULL, NULL}  /* sentinel */
 };
 

--- a/Tools/scripts/run_tests.py
+++ b/Tools/scripts/run_tests.py
@@ -10,6 +10,7 @@ simply passing a -u option to this script.
 import os
 import sys
 import test.support
+import importlib
 
 
 def is_multiprocess_flag(arg):
@@ -27,6 +28,9 @@ def main(regrtest_args):
             '-bb',                # Warnings about bytes/bytearray
             '-E',                 # Ignore environment variables
             ]
+
+    if importlib.is_lazy_imports_enabled():
+        args.extend(['-L'])
 
     # Allow user-specified interpreter options to override our defaults.
     args.extend(test.support.args_from_interpreter_flags())


### PR DESCRIPTION
# Summary
- Add `importlib.is_lazy_imports_enabled`
- Add `make test_with_lazy_imports` to allow users run the test suite with Lazy Imports
- Add `@unittest.skipIfLazyImportsIsDisabled` for skipping some tests when Lazy Imports is disabled
- Add `@unittest.skipIfLazyImportsIsEnabled` for skipping some tests when Lazy Imports is enabled
- Add `Lib/test/test_lazy_imports.py` to validate this framework

# Test Plan

> **Notes:**
> All these tests were executed in **cinder/3.10**. 
> This is a crashy branch, so somethings might not work here.


## 1. Test the behavior in `test_lazy_imports.py`
We will cover the testing of these four features in this section.
- `@unittest.skipIfLazyImportsIsDisabled`
- `@unittest.skipIfLazyImportsIsEnabled`
- `importlib.is_lazy_imports_enabled()`
- `test_lazy_imports.py`

---

When I remove `@unittest.skipIfLazyImportsIsDisabled` (line 8) and `@unittest.skipIfLazyImportsIsEnabled` (line 12) in `test_lazy_imports.py`, no matter this test is executed with or without Lazy Imports, the unit test will fail.

<img width="1232" alt="image" src="https://user-images.githubusercontent.com/18440101/176560268-0addf026-432a-4890-b9a4-7846376903ac.png">

### With Lazy Imports
**Run**
```
./python -L -m test test_lazy_imports
```
**Expected results**

It will fail in `test_lazy_imports_is_disabled` because Lazy Imports is enabled.
<img width="1242" alt="image" src="https://user-images.githubusercontent.com/18440101/176560312-e9fd2d79-4d25-4d30-bac7-7a2dda7a950c.png">

### Without Lazy Imports
**Run**
```
./python -m test test_lazy_imports
```
**Expected results**
It will fail in `test_lazy_imports_is_enabled` because Lazy Imports is not enabled.
<img width="1245" alt="image" src="https://user-images.githubusercontent.com/18440101/176560341-c0949ca0-e16f-400d-8b10-e0a84b9b7164.png">


---

When I add `@unittest.skipIfLazyImportsIsDisabled` (line 8) and `@unittest.skipIfLazyImportsIsEnabled` (line 12) into `test_lazy_imports.py`, the unit test can be passed with or without Lazy Imports.

<img width="1242" alt="image" src="https://user-images.githubusercontent.com/18440101/176560366-5fb69aed-963f-4241-ac2d-b497209d730f.png">(same as the original `test_lazy_imports.py` )

### With Lazy Imports
**Run**
```
./python -L -m test test_lazy_imports
```
**Expected results**

<img width="1245" alt="image" src="https://user-images.githubusercontent.com/18440101/176560428-ccb00284-cdc7-406f-88c4-2dc2b4d375ae.png">

### Without Lazy Imports
**Run**
```
./python -m test test_lazy_imports
```
**Expected results**

<img width="1228" alt="image" src="https://user-images.githubusercontent.com/18440101/176560446-0eae80d6-495e-444b-bdb1-a633dd220140.png">

---
## 2. Test the framework
We add a new target, `test_with_lazy_imports`, in `Makefile`, so that we can easily validate the test suite with Lazy Imports by using `make test_with_lazy_imports`.

### Test suite with Lazy Imports

If we run `make test_with_lazy_imports`, we would like to make every testing execute with Lazy Imports. To validate this, I remove some code in `test_lazy_imports.py`. We only leave `test_lazy_imports_is_enabled`.

<img width="1224" alt="image" src="https://user-images.githubusercontent.com/18440101/176560479-d5ef3975-b4f7-4b90-9009-6ad7d5e6645d.png">

Then, we can observe if it still can pass `test_lazy_imports.py`.
If it passes, all the tests are executed with Lazy Imports. Otherwise, `make test_with_lazy_imports` failed.

**Run**
```
make test_with_lazy_imports
```

**Expected results**
We expected `test_lazy_imports` did not fail during the validation. That is, it didn't show in the tests failed list.

<img width="958" alt="image" src="https://user-images.githubusercontent.com/18440101/176560522-885582f4-d00a-4641-8ae1-0b7e094d220d.png">

### Test suite without Lazy Imports
This test suite existed in the code. We could use `make test` to execute it, and the results should be the same as before.
