### PR TITLE
deltablue: declare dst before while loop

### DIFF
--- a/Tools/benchmarks/deltablue_static_basic_lib.py
+++ b/Tools/benchmarks/deltablue_static_basic_lib.py
@@ -629,6 +629,7 @@ def projection_test(n: int) -> None:
     dests = OrderedCollection()
 
     i = 0
+    dst = Variable("dst%s" % 0, 0)
     while i < n:
         src = Variable("src%s" % i, i)
         dst = Variable("dst%s" % i, i)


### PR DESCRIPTION
Fix a type error

I was running commit fa0ed519af6c131ec141f7bd14ab12a4aa7afc1b

`python -m compiler --static deltablue...py`  gave this error:

```
....
  File "/vol/Lib/compiler/static/visitor.py", line 44, in visit
    return super().visit(node, *args)
  File "/vol/Lib/compiler/visitor.py", line 70, in visit
    return meth(node, *args)
  File "/vol/Lib/compiler/static/type_binder.py", line 1592, in visitName
    raise TypedSyntaxError(f"Name `{node.id}` is not defined.")
  File "main.py", line 645
    if dst.value != 1170:
      ^
compiler.errors.TypedSyntaxError: Name `dst` is not defined.
```

All better with this fix.