### PR TITLE
Build and copy _cinderx and cinderx in Dockerfile

### DIFF
--- a/.github/workflows/cinder/Dockerfile
+++ b/.github/workflows/cinder/Dockerfile
@@ -11,8 +11,9 @@ ENV MAKE_JOBS="${make_jobs}" MAKE_VERBOSE="${make_verbose:-1}"
 WORKDIR /cinder/build
 COPY --chmod=r . /cinder/src
 RUN cp /cinder/src/oss-cinder-test.sh /cinder/build/
-RUN /cinder/src/configure --prefix=/cinder
+RUN /cinder/src/configure --prefix=/cinder --enable-cinderx-module
 RUN make -j${MAKE_JOBS:-$( nproc )} VERBOSE=$MAKE_VERBOSE
+RUN make -j${MAKE_JOBS:-$( nproc )} VERBOSE=$MAKE_VERBOSE cinderx_module
 
 # The "install" image - install the built Python and discard the source and build trees
 FROM build as install

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1672,6 +1672,11 @@ libinstall:	build_all $(srcdir)/Modules/xxmodule.c
 			echo $(INSTALL_DATA) $$i $(LIBDEST); \
 		fi; \
 	done
+	cp -r $(srcdir)/cinderx/cinderx/ $(DESTDIR)$(LIBDEST)
+	cp -r $(srcdir)/cinderx/__static__/ $(DESTDIR)$(LIBDEST)
+	cp -r $(srcdir)/cinderx/__strict__/ $(DESTDIR)$(LIBDEST)
+	cp -r $(srcdir)/cinderx/compiler/ $(DESTDIR)$(LIBDEST)
+	cp '$(abs_builddir)/$(shell cat "$(abs_builddir)/pybuilddir.txt")/_cinderx.$(SOABI).so' $(DESTDIR)$(LIBDEST)
 	@if test "$(TEST_MODULES)" = yes; then \
 		subdirs="$(LIBSUBDIRS) $(TESTSUBDIRS)"; \
 	else \


### PR DESCRIPTION
This at least builds _cinderx.so (which wasn't being built before) and bundles cinderx into the installed lib/, but currently fails to import _cinderx with:

    >>> import cinderx
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/home/max/Documents/code/cinder/dst/lib/python3.10/cinderx/__init__.py", line 12, in <module>
        from _cinderx import (
    ImportError: /home/max/Documents/code/cinder/dst/lib/python3.10/_cinderx.cpython-310-x86_64-linux-gnu.so: undefined symbol: crc32

Which I don't know how to solve yet.