### PR TITLE
fix configure flipping --enable-cinderx-module

### DIFF
--- a/configure
+++ b/configure
@@ -807,6 +807,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -936,6 +937,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1188,6 +1190,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1325,7 +1336,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1478,6 +1489,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -1539,8 +1551,7 @@ Optional Features:
   --disable-test-modules  don't build nor install test modules
   --enable-cinder-ref-debug
                           Enable Cinder refcount debugging
-  --disable-cinderx-module
-                          build CinderX module
+  --enable-cinderx-module build CinderX module
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -18216,15 +18227,15 @@ $as_echo_n "checking whether to build CinderX module... " >&6; }
 # Check whether --enable-cinderx-module was given.
 if test "${enable_cinderx_module+set}" = set; then :
   enableval=$enable_cinderx_module;
-  ENABLE_CINDERX_MODULE=no
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-else
-
   ENABLE_CINDERX_MODULE=yes
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
+
+else
+
+  ENABLE_CINDERX_MODULE=no
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -6149,14 +6149,14 @@ AC_ARG_ENABLE(cinder-ref-debug,
 
 AC_MSG_CHECKING(whether to build CinderX module)
 AC_ARG_ENABLE(cinderx-module,
-    AS_HELP_STRING([--disable-cinderx-module], [build CinderX module]),
-[
-  ENABLE_CINDERX_MODULE=no
-  AC_MSG_RESULT([no])
-],
+    AS_HELP_STRING([--enable-cinderx-module], [build CinderX module]),
 [
   ENABLE_CINDERX_MODULE=yes
   AC_MSG_RESULT([yes])
+],
+[
+  ENABLE_CINDERX_MODULE=no
+  AC_MSG_RESULT([no])
 ])
 
 AC_SUBST(ENABLE_CINDERX_MODULE)


### PR DESCRIPTION
This commit fixes `configure` and `configure.ac` which was previously incorrectly treating `--enable-cinderx-module` as
a `--disable-cinderx-module`.

Before:
```
/Volumes/Workspace/cinder-git cinder/3.10*
❯ ./configure --enable-cinderx-module | rg "whether to build CinderX module"
checking whether to build CinderX module... no
```

After:
```
/Volumes/Workspace/cinder-git cinder/3.10*
❯ ./configure --enable-cinderx-module | rg "whether to build CinderX module"
checking whether to build CinderX module... yes
```