### PR TITLE
[oss] Fix `x86-ffi64` Call to alloca in a loop

### DIFF
--- a/Modules/_ctypes/libffi_osx/x86/x86-ffi64.c
+++ b/Modules/_ctypes/libffi_osx/x86/x86-ffi64.c
@@ -712,7 +712,11 @@ ffi_closure_unix64_inner(
 		/* Otherwise, allocate space to make them consecutive.  */
 		else
 		{
-			char *a = alloca (16);
+			char *a = (char *)malloc(16);
+			if (!a) {
+				/* Handle allocation failure */
+				abort();
+			}
 			int j;
 
 			avalue[i] = a;
@@ -724,6 +728,7 @@ ffi_closure_unix64_inner(
 				else
 					memcpy (a, &reg_args->gpr[gprcount++], 8);
 			}
+			free(avalue[i]);
 		}
 	}
 


### PR DESCRIPTION
https://github.com/facebookincubator/cinder/blob/33e97ac365e84fbc5a89faaf72a041858f4197d9/Modules/_ctypes/libffi_osx/x86/x86-ffi64.c#L715-L715

Fix the issue will replace the `alloca` call with a `malloc` call to allocate memory on the heap. This ensures that memory is not tied to the stack and avoids the risk of stack overflow. The allocated memory will be freed at the end of each loop iteration to prevent memory leaks.

**Steps to fix:**
1. Replace the `alloca(16)` call with a `malloc(16)` call.
2. Add a `free(a)` statement at the end of the loop to release the allocated memory.
3. Ensure that the changes do not alter the existing functionality of the code.

---


The variable `path` is allocated inside a loop with `alloca`. Consequently, storage for all copies of the path is present in the stack frame until the end of the function.
```c
char *dir_path;
char **dir_entries;
int count;

for (int i = 0; i < count; i++) {
  char *path = (char*)alloca(strlen(dir_path) + strlen(dir_entry[i]) + 2);
  // use path
}
```
In the revised path is `allocated` with `malloc` and freed at the end of the loop.
```c
char *dir_path;
char **dir_entries;
int count;

for (int i = 0; i < count; i++) {
  char *path = (char*)malloc(strlen(dir_path) + strlen(dir_entry[i]) + 2);
  // use path
  free(path);
}
```
#### References
[ALLOCA(3)](http://man7.org/linux/man-pages/man3/alloca.3.html)
[CWE-770](https://cwe.mitre.org/data/definitions/770.html)