### PR TITLE
fix HTTP Response Splitting on `gen`

### DIFF
--- a/Tools/scripts/ir_viz/gen.py
+++ b/Tools/scripts/ir_viz/gen.py
@@ -290,7 +290,8 @@ def make_explorer_class(process_args, prod_hostname=None):
         def do_404(self):
             try:
                 static_file = os.path.join(TEMPLATE_DIR, self.path.lstrip("/"))
-                content_type = mimetypes.guess_type(static_file)[0] or "text/html"
+                guessed_type = mimetypes.guess_type(static_file)[0]
+                content_type = guessed_type if guessed_type in mimetypes.types_map.values() else "application/octet-stream"
                 with open(static_file, "rb") as f:
                     self._begin_response(200, content_type)
                     self.end_headers()


### PR DESCRIPTION
https://github.com/facebookincubator/cinder/blob/d23f7f737b23e3d81db8756e689bd482cfd9f084/Tools/scripts/ir_viz/gen.py#L267-L267

To fix the issue, we need to sanitize the `content_type` value before using it in the `send_header` method. Specifically:
1. Validate the `content_type` returned by `mimetypes.guess_type` to ensure it is a safe and expected MIME type.
2. If the `content_type` is invalid or unexpected, fall back to a default MIME type (e.g., `application/octet-stream` or `text/html`).

The changes will be made in the `do_404` method where `content_type` is determined and used.

---


