### PR TITLE
Security: Path Traversal in MIME Unpacker

### DIFF
--- a/Doc/includes/email-unpack.py
+++ b/Doc/includes/email-unpack.py
@@ -35,8 +35,6 @@ Unpack a MIME message into a directory of files.
         # multipart/* are just containers
         if part.get_content_maintype() == 'multipart':
             continue
-        # Applications should really sanitize the given filename so that an
-        # email message can't be used to overwrite important files
         filename = part.get_filename()
         if not filename:
             ext = mimetypes.guess_extension(part.get_content_type())
@@ -44,6 +42,8 @@ Unpack a MIME message into a directory of files.
                 # Use a generic bag-of-bits extension
                 ext = '.bin'
             filename = f'part-{counter:03d}{ext}'
+        else:
+            filename = os.path.basename(filename)
         counter += 1
         with open(os.path.join(args.directory, filename), 'wb') as fp:
             fp.write(part.get_payload(decode=True))


### PR DESCRIPTION
## Summary

Security: Path Traversal in MIME Unpacker

## Problem

**Severity**: `High` | **File**: `Doc/includes/email-unpack.py:L44`

The `email-unpack.py` script extracts attachments from a MIME message and writes them to the filesystem using the filename provided in the email. The code explicitly acknowledges that it lacks filename sanitization. An attacker can craft an email with a malicious filename (e.g., `../../../etc/cron.d/evil`) to write files outside the intended directory, leading to arbitrary file overwrite or code execution.

## Solution

Sanitize the filename using `os.path.basename` and ensure it does not contain path separators or resolve to a location outside the target directory. Alternatively, generate a safe, random filename for each attachment.

## Changes

- `Doc/includes/email-unpack.py` (modified)